### PR TITLE
Change: Handlers behavior for Docker install

### DIFF
--- a/docker/roles/install/handlers/main.yml
+++ b/docker/roles/install/handlers/main.yml
@@ -2,7 +2,7 @@
 # handlers file for quanticware.docker
 
 - name: Docker_restart
-  ansible.builtin.systemd:
+  ansible.builtin.systemd_service:
     state: restarted
     name: docker
     enabled: true

--- a/docker/roles/install/tasks/install.yml
+++ b/docker/roles/install/tasks/install.yml
@@ -80,3 +80,6 @@
     mode: '0600'
   when: docker_dns_configuration
   notify: "Docker_restart"
+
+- name: "Docker Install | Restart Docker"
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
Put flush_handlers to avoid Docker restart at the end of Hashistack install play